### PR TITLE
Cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,7 @@ Note: the internal variables ```.send, .frame, .self``` will be available during
 
 source_processing:
 
-  - test_except_catch_adjust (has no tests written)
-  - test closing up of brackets for both unpack + clean_source_lines (recent fixes that used is_item)
-  - test recent fix in is_item at test_is_item (async fix)
-  - unpack + clean_source_lines recent issues + fixes
+  - unpack + clean_source_lines recent issues + fixes (bracket issues) (indentation of unpacked lines, closing up of brackets, and bracketed (open brackets) expressions, exceptions, ExceptionGroups, nested exceptions) -- need to fix newlines and comments handling
 
 ### Review for testing:
 
@@ -158,21 +155,8 @@ source_processing:
 - decorators needs checking
 - value yields e.g. decorators/functions/ternary
 - loops
-- indentation of lines from unpacking in clean_source_lines needs checking
-
-Initialized Generators:
-- check the lineno from unpacking for initialized generators
-  - check that all unpacked lines are indented where necessary
-    and indentation of future lines must also be considered
-- lineno for initialized generators needs checking
 
 check block_adjust
-
-unpack:
-- check the line continuation is adjusting correctly
-or consider removing char in " \\" case since it's
-only for formatting
-
 
 version specific:
 
@@ -181,10 +165,34 @@ version specific:
 - in python 3.14 exceptions don't need brackets
 
 ### Figure out later:
+  Initialized Generators:
+  - lineno for initialized generators needs checking
+  - check the lineno from unpacking for initialized generators
+    - check that all unpacked lines are indented where necessary and indentation of future lines must also be considered
+
+    Additional notes on this:
+    will need to create an instruction index linetable. Needed to know where to start for initialized
+    generators. Though will not know what the prior send values are so will have to run the unpacked
+    lines regardless of what the prior send values are or None if there are no prior send values or these
+    are not retrievable.
+    i.e.
+    e.g. line -> instruction index -> unpacked line range
+    ```python
+    instr_linetable = {
+        1: { # key = lineno -> value = dict of # key = instruction index -> value = range in source code
+            0: [0,3],
+            3: [12,23]
+        }
+    }
+    ```
   - fix and/or add lineno adjust. Then use this for compound statements tracking
   - try to implement ag_await for AsyncGenerator if possible (then test this)
+  - enhance code comparisons for source_code_from_comparison for better extraction
 
   utils:
   - test utils.cli_getsource
   - determine the initial lineno given encapsulated yield and the send values for initialized generators
     - test_lambda_expr in test_custom_generator for encapsulated yields
+
+  generators:
+  - test_lambda_expr in test_custom_generator for encapsulated yields

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Note: the internal variables ```.send, .frame, .self``` will be available during
 finish testing + review everything
 
 clean_source_lines:
+
   to be checked:
   - indentation of lines from unpacking in clean_source_lines needs checking
   - test closing up of brackets for both unpack + clean_source_lines
@@ -163,19 +164,21 @@ unpack:
   or consider removing char in " \\" case since it's
   only for formatting
 
+- use look aheads to avoid unnecessary code adjustments
+
 
 Figure out later:
+
   source_processing:
-    - fix extract_function for expr_getsource tests
-      - then test it in test_source_processing:
-        - test_expr_getsource
-        - test_extract_function
+
+- fix extract_function for expr_getsource tests
+  - then test it in test_source_processing:
+    - test_expr_getsource
+    - test_extract_function
 
 - examples of how to use ag_await and then cater for it if relevant
 
 utils:
   - test utils.cli_getsource
-- consider making patch iterators scope specific
-  - finish testing patch_iterators with testing this
 - consider determining lineno given encapsulated yield and the send values
   - test_lambda_expr in test_custom_generator for encapsulated yields

--- a/README.md
+++ b/README.md
@@ -141,44 +141,50 @@ Note: the internal variables ```.send, .frame, .self``` will be available during
 
 # TODO
 
-finish testing + review everything
+### Finish writing tests for:
 
-clean_source_lines:
+source_processing:
 
-  to be checked:
-  - indentation of lines from unpacking in clean_source_lines needs checking
-  - test closing up of brackets for both unpack + clean_source_lines
-  - collect lambda needs checking
-  - decorators needs checking
-  - value yields e.g. decorators/functions/ternary
-  - loops
-  - check the lineno from unpacking for initialized generators
-    - check that all unpacked lines are indented where necessary
-      and indentation of future lines must also be considered
-  - lineno for initialized generators needs checking
+  - test_except_catch_adjust (has no tests written)
+  - test closing up of brackets for both unpack + clean_source_lines (recent fixes that used is_item)
+  - test recent fix in is_item at test_is_item (async fix)
+  - unpack + clean_source_lines recent issues + fixes
+
+### Review for testing:
+
+  clean_source_lines:
+  
+- collect_lambda needs checking
+- decorators needs checking
+- value yields e.g. decorators/functions/ternary
+- loops
+- indentation of lines from unpacking in clean_source_lines needs checking
+
+Initialized Generators:
+- check the lineno from unpacking for initialized generators
+  - check that all unpacked lines are indented where necessary
+    and indentation of future lines must also be considered
+- lineno for initialized generators needs checking
 
 check block_adjust
 
 unpack:
 - check the line continuation is adjusting correctly
-  or consider removing char in " \\" case since it's
-  only for formatting
-
-- use look aheads to avoid unnecessary code adjustments
+or consider removing char in " \\" case since it's
+only for formatting
 
 
-Figure out later:
+version specific:
 
-  source_processing:
+- in python 3.14 t-strings were added (treat as f-strings on unpacking)
+- in python 3.12 you can arbitarily do nested f-strings but in earlier versions you cannot (update the nesting checker in the string_collectors)
+- in python 3.14 exceptions don't need brackets
 
-- fix extract_function for expr_getsource tests
-  - then test it in test_source_processing:
-    - test_expr_getsource
-    - test_extract_function
+### Figure out later:
+  - fix and/or add lineno adjust. Then use this for compound statements tracking
+  - try to implement ag_await for AsyncGenerator if possible (then test this)
 
-- examples of how to use ag_await and then cater for it if relevant
-
-utils:
+  utils:
   - test utils.cli_getsource
-- consider determining lineno given encapsulated yield and the send values
-  - test_lambda_expr in test_custom_generator for encapsulated yields
+  - determine the initial lineno given encapsulated yield and the send values for initialized generators
+    - test_lambda_expr in test_custom_generator for encapsulated yields

--- a/gcopy/custom_generator.md
+++ b/gcopy/custom_generator.md
@@ -397,3 +397,6 @@ You should see that I've made a custom ```code``` and ```frame``` class that als
   - on ```BaseGenerator.__init__()``` the locals are still the same pointers in the original frame and thus instantiating a i.e. ```Generator``` or ```AsyncGenerator``` type will create pointers essentially. To avoid this, deepcopy the generator after instantiation.
 
   - f-strings are unpacked. We could check if they need to be unpacked however it's likely about the same or worse than being unpacked without checking.
+
+  - Because bytecode changes with python versions the main functions to look out for in terms of
+  instability should start likely with the functions found in utils.py: code_setup, code_attrs, similar opcode, and code_cmp. Though, code_setup is likely the only and most unstable of them that needs review per version change.

--- a/gcopy/custom_generator.md
+++ b/gcopy/custom_generator.md
@@ -398,5 +398,7 @@ You should see that I've made a custom ```code``` and ```frame``` class that als
 
   - f-strings are unpacked. We could check if they need to be unpacked however it's likely about the same or worse than being unpacked without checking.
 
+  - case statements in python cannot take yields and therefore no adjustments needed in terms of yield.
+
   - Because bytecode changes with python versions the main functions to look out for in terms of
   instability should start likely with the functions found in utils.py: code_setup, code_attrs, similar opcode, and code_cmp. Though, code_setup is likely the only and most unstable of them that needs review per version change.

--- a/gcopy/custom_generator.py
+++ b/gcopy/custom_generator.py
@@ -319,7 +319,7 @@ class BaseGenerator:
                         self._internals["lineno"] += 1 - bool(
                             get_loops(
                                 self._internals["lineno"],
-                                self._internals["jump_positions"],
+                                self._internals.get("jump_positions", []),
                             )
                         )
                     track_shift(FUNC, self._locals().get(".internals", {}))
@@ -390,7 +390,7 @@ class BaseGenerator:
                 ## uses (since it'll become an empty generator) which is 
                 ## unusual/unexpected behavior) ##
                 self._internals["state_generator"] = self._init_states()
-        self._internals["loops"] = get_loops(self._internals["lineno"], self._internals["jump_positions"])
+        self._internals["loops"] = get_loops(self._internals["lineno"], self._internals.get("jump_positions", []))
         ## if no state then it must be EOF ##
         while self._internals["state"]:
             yield self._create_state()
@@ -541,7 +541,7 @@ class BaseGenerator:
         else:
             ## update the lineno ##
             self._internals["lineno"] = self._internals["linetable"][adjusted_lineno] + 1
-            loops = self._internals["loops"] = get_loops(self._internals["lineno"], self._internals["jump_positions"])
+            loops = self._internals["loops"] = get_loops(self._internals["lineno"], self._internals.get("jump_positions", []))
             if not loops:
                 ## if we can advance the lineno then advance it ##
                 ## else (since not in loop) EOF ##

--- a/gcopy/source_processing.py
+++ b/gcopy/source_processing.py
@@ -1527,14 +1527,15 @@ def extract_source_from_comparison(
         try:  ## we need to make it a try-except in case of potential syntax errors towards the end of the line/s ##
             ## eval should be safe here assuming we have correctly extracted the expression - we can't use compile because it gives a different result ##
             temp_source = source[col_offset:end_col_offset]
+            temp_code = compile(temp_source, "<Don't track>", mode) ## very important, because track_iter otherwise will interfere with the comparison ##
             try:
-                genexpr = executor(temp_source, globals, locals)
+                genexpr = executor(temp_code, globals, locals)
             except NameError as e:
                 if not extracing_genexpr:
                     raise e
                 ## NameError since genexpr's first iterator is stored as .0 ##
                 name = e.args[0].split("'")[1]
-                genexpr = executor(temp_source, globals, locals | {name: locals[".0"]})
+                genexpr = executor(temp_code, globals, locals | {name: locals[".0"]})
             try:
                 temp_code = getcode(genexpr)
                 if temp_code.co_name != code_obj.co_name:

--- a/gcopy/source_processing.py
+++ b/gcopy/source_processing.py
@@ -2,21 +2,18 @@
 ### cleaning/extracting/adjusting source code ###
 #################################################
 
-## needed to access c level memory for the builtin iterators ##
-from functools import partial, wraps
+from functools import partial
 from inspect import currentframe, findsource, getsource, signature
 from itertools import chain
 from sys import version_info
-from types import CodeType  # , FrameType ## lineno_adjust
-from types import CellType, FrameType, FunctionType, GeneratorType
-from typing import Any, Callable, Iterable, Iterator
+from types import CodeType, CellType, FunctionType, GeneratorType# , FrameType ## lineno_adjust
+from typing import Any, Iterable
 
 ## to ensure gcopy.custom_generator.Generator can be used in exec for sign ##
 from gcopy.track import get_indent, track_adjust
 from gcopy.utils import (
     attr_cmp,
     cli_findsource,
-    code_attrs,
     code_cmp,
     empty_generator,
     get_nonlocals,
@@ -1897,7 +1894,11 @@ def sign(
     closure: tuple[CellType] = None,
 ) -> FunctionType:
     """signs a function with the signature of another function"""
+    annotations = FUNC2.__annotations__
+    # temporarily remove the annotations from the signature to avoid scope issues
+    FUNC2.__annotations__ = {}
     _signature = format(signature(FUNC2))
+    FUNC2.__annotations__ = annotations
     if boundmethod:
         _signature = "(self, " + _signature[1:]
     _signature = FUNC2.__name__ + _signature + ":"
@@ -1908,6 +1909,7 @@ def sign(
     temp = locals()[FUNC2.__name__]
     temp.__source__ = source
     temp.__doc__ = FUNC2.__doc__
+    temp.__annotations__ = annotations
     return temp
 
 
@@ -1943,8 +1945,10 @@ def custom_adjustment(self: object, line: str, number_of_indents: int = 0) -> li
     result = yield_adjust(temp_line, indent)
     if temp_line.startswith("yield from "):
         lineno = self.lineno
-        ## lineno + 1 since this is not a loop ##
-        self.jump_positions += [[lineno + 1, lineno + len(result)]]
+        self.lineno += len(result) - 1
+        ## lineno + 1 it starts after this line ##
+        ## and lineno + len(result) - 1 to include the full loops block subtract the current line ##
+        self.jump_positions += [[lineno + 1, self.lineno]]
     if result is not None:
         return result
     ## loops ##
@@ -2212,7 +2216,7 @@ def clean_source_lines(gen: object, running: bool = False) -> None:
 
     1. fixes any indentation issues (when ';' is used) and skips empty lines
     2. split on "\n", ";", and ":"
-    3. join up the line continuations i.e. "\ ... " will be skipped
+    3. join up the line continuations i.e. "\\ ... " will be skipped
 
     additionally, custom_adjustment will be called on each line formation as well
 

--- a/gcopy/utils.py
+++ b/gcopy/utils.py
@@ -108,13 +108,6 @@ def hasattrs(self: Any, attrs: Iterable[str]) -> bool:
     return True
 
 
-def chain(*iterators: tuple[Iterable]) -> GeneratorType:
-    """appends iterators together to yield from one after the other"""
-    for iterator in iterators:
-        for value in iterator:
-            yield value
-
-
 def get_nonlocals(FUNC: FunctionType) -> dict:
     """Gets the nonlocals or closure variables of a function"""
     cells = getattr(FUNC, "__closure__", None)
@@ -245,6 +238,9 @@ class Wrapper:
     Note: type checking will fail. Therefore, you may consider monkey patching
     i.e. isinstance and issubclass if necessary.
 
+    The reason why it should fail is because we're only using it by the instance
+    and not the type. If we wanted it by the type then we should create a metaclass.
+
     Also, the intended use case doesn't support i.e. binary operations or type
     casting therefore it's not support by this wrapper. The wrapper is only as
     storage for instance based members (data and methods)
@@ -336,7 +332,7 @@ def is_running(iter: Iterable) -> bool:
     index = get_iter_index(iter)
     return index > 0 or index < -1
 
-
+## used in get_iter_index for an instance based check since no such type is in .py stdlib (I think) ##
 memory_iterator = type(iter(memoryview(bytearray())))
 
 

--- a/tests/test_source_processing.py
+++ b/tests/test_source_processing.py
@@ -1,3 +1,9 @@
+# test_lineno_adjust() ## not going to be implemented at present time ##
+## tested in unpack_genexpr: update_line
+## tested in test_unpack: named_adjust, unpack_adjust, update_lines, check_ID
+# tested in control_flow_adjust: statement_adjust
+## Generator source cleaning is tested in test_custom_generator ##
+
 from sys import version_info
 from types import FunctionType
 from typing import Iterable
@@ -15,7 +21,6 @@ from gcopy.source_processing import (
     extract_genexpr,
     extract_lambda,
     extract_source_from_comparison,
-    genexpr_adjust,
     get_indent,
     get_loops,
     get_signature,
@@ -34,16 +39,13 @@ from gcopy.source_processing import (
     sign,
     signature,
     singly_space,
-    skip_alt_stmnt_proxy,
     skip_alternative_statements,
     skip_blocks,
     skip_line_continuation,
     skip_source_definition,
-    string_collector_adjust,
     string_collector_proxy,
     ternary_adjust,
     unpack,
-    unpack_adjust,
     unpack_genexpr,
     unpack_lambda,
     update_depth,
@@ -115,7 +117,7 @@ def test_unpack_genexpr() -> None:
 
 
 def test_skip_line_continuation() -> None:
-    source = "\     \n     hi"
+    source = "\\     \n     hi"
     source_iter = enumerate(source)
     index, char = next(source_iter)
     skip_line_continuation(source_iter, source, index)
@@ -1260,53 +1262,3 @@ def test_sign() -> None:
     assert signature(f) == signature(test)
     assert f.__doc__ == test.__doc__
     assert f.__annotations__ == test.__annotations__
-
-
-if __name__ == "__main__":
-    # TODO can remove, simply run pytest .
-    test_update_depth()
-    test_get_indent()
-    # test_lineno_adjust() ## not going to be implemented at present time ##
-    test_line_adjust()
-    ## tested in unpack_genexpr: update_line
-    test_unpack_genexpr()
-    test_skip_line_continuation()
-    test_skip_source_definition()
-    test_collect_string()
-    test_collect_multiline_string()
-    test_string_collector_proxy()
-    test_inverse_bracket()
-    ## tested in test_unpack: named_adjust, unpack_adjust, update_lines, check_ID
-    test_is_item()
-    test_unpack()
-    test_ternary_adjust()
-    test_collect_definition()
-    test_is_alternative_statement()
-    test_is_loop()
-    test_is_definition()
-    test_skip_alternative_statements()
-    # tested in control_flow_adjust: statement_adjust
-    test_control_flow_adjust()
-    test_indent_lines()
-    test_iter_adjust()
-    test_is_statement()
-    test_skip_blocks()
-    test_loop_adjust()
-    test_yield_adjust()
-    test_get_loops()
-    test_extract_source_from_comparison()
-    test_expr_getsource()
-    test_extract_genexpr()
-    test_extract_lambda()
-    test_extract_function()
-    test_except_adjust()
-    test_extract_as()
-    test_except_catch_adjust()
-    test_singly_space()
-    test_outer_loop_adjust()
-    test_setup_next_line()
-    test_unpack_lambda()
-    test_get_signature()
-    test_collect_lambda()
-    test_sign()
-    ## Generator source cleaning is tested in test_custom_generator ##

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,10 +1,12 @@
 import asyncio
 from collections.abc import Iterable, Iterator
+import builtins
+from typing import Union
 
 from gcopy.track import (
     atrack,
     currentframe,
-    get_builtin_iterators,
+    get_iterators,
     patch_iterators,
     track,
     track_adjust,
@@ -13,7 +15,7 @@ from gcopy.track import (
 )
 
 
-def iter_init(obj: Iterable | Iterator) -> Iterable:
+def iter_init(obj: Union[Iterable, Iterator]) -> Iterable:
     """Initializes iterators (for testing)"""
     if obj.__name__ in ("memoryview",):
         return iter(obj(b"abcedfg"))
@@ -29,7 +31,7 @@ def iter_init(obj: Iterable | Iterator) -> Iterable:
 
 def test_track_adjust() -> None:
     dct = {".mapping": [34, 35, 74], ".34": None, ".35": None, ".74": None}
-    assert track_adjust(dct)
+    assert track_adjust(dct) is None
     assert list(dct.keys()) == [".4", ".8", ".12"]
 
 
@@ -61,7 +63,8 @@ def test_patch_iterators() -> None:
     assert not isinstance(range, track)
     ## globals ##
     patch_iterators(globals())
-    iterators = get_builtin_iterators()
+    # , itertools, collections, merge=True
+    iterators = get_iterators(builtins)
     for name in iterators:
         assert type(globals()[name]) == track
     ## unpatch the iters ##

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,7 +1,5 @@
-import asyncio
-from collections.abc import Iterable, Iterator
+import pytest ## used to make async tests work
 import builtins
-from typing import Union
 
 from gcopy.track import (
     atrack,
@@ -13,20 +11,6 @@ from gcopy.track import (
     track_shift,
     unpatch_iterators,
 )
-
-
-def iter_init(obj: Union[Iterable, Iterator]) -> Iterable:
-    """Initializes iterators (for testing)"""
-    if obj.__name__ in ("memoryview",):
-        return iter(obj(b"abcedfg"))
-    elif obj.__name__ in ("enumerate", "reversed"):
-        return iter(obj([]))
-    elif obj.__name__ == "range":
-        return iter(obj(2))
-    elif obj.__name__ in ("zip", "filter", "map"):
-        return iter(obj([], []))
-    else:
-        return iter(obj())
 
 
 def test_track_adjust() -> None:
@@ -112,7 +96,7 @@ def test_track() -> None:
     iter(track([1, 2, 3]))
     assert [i for i in locals()[".internals"][".4"]] == [1, 2, 3]
 
-
+@pytest.mark.asyncio
 async def test_atrack() -> None:
     async def iterator():
         yield 1
@@ -122,8 +106,3 @@ async def test_atrack() -> None:
     assert [i async for i in atrack(iterator())] == [1, 2, 3]
     aiter(atrack(iterator()))
     assert [i async for i in locals()[".internals"][".4"]] == [1, 2, 3]
-
-
-if __name__ == "__main__":
-    # TODO can remove, simply run pytest .
-    asyncio.run(test_atrack())

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -43,6 +43,23 @@ def test_track_shift() -> None:
 
 
 def test_patch_iterators() -> None:
+
+    assert not isinstance(range, track)
+    ## test scoping ##
+    @patch_iterators
+    def test_scope():
+        assert isinstance(range, track)
+
+    test_scope()
+    
+    assert not isinstance(range, track)
+    ## class ##
+    class test:
+        patch_iterators()
+        assert isinstance(range, track)
+    
+    assert not isinstance(range, track)
+    ## globals ##
     patch_iterators(globals())
     iterators = get_builtin_iterators()
     for name in iterators:
@@ -51,7 +68,6 @@ def test_patch_iterators() -> None:
     unpatch_iterators(globals())
     for name in iterators:
         assert globals().get(name, None) is None
-    ## try in local scope only ##
 
 
 def test_track_iter() -> None:
@@ -72,21 +88,6 @@ def test_track_iter() -> None:
             pass
     assert test(4, "list_iterator")
     assert test(8, "list_iterator")
-
-
-def test_track_iter_inside_exec() -> None:
-    # TODO works when run pytest . but not in isolation
-    FUNC_code = compile(
-        """def test():
-    for i in range(3):
-         return locals()[".internals"][".0"]
-""",
-        currentframe().f_code.co_filename,
-        "exec",
-    )
-    exec(FUNC_code, globals(), locals())
-    range_iterator = locals()["test"]()
-    assert [i for i in range_iterator] == [1, 2]
 
 
 def test_track_iter_inside_Generator() -> None:
@@ -122,11 +123,4 @@ async def test_atrack() -> None:
 
 if __name__ == "__main__":
     # TODO can remove, simply run pytest .
-    test_track_adjust()
-    test_track_shift()
-    test_patch_iterators()
-    test_track_iter()
-    test_track_iter_inside_exec()
-    test_track_iter_inside_Generator()
-    test_track()
     asyncio.run(test_atrack())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,6 @@
 import warnings
 from sys import version_info
 from types import CodeType, FrameType
-from typing import Iterator
 
 from gcopy.utils import (
     attr_cmp,
@@ -18,7 +17,6 @@ from gcopy.utils import (
     getframe,
     hasattrs,
     is_cli,
-    is_running,
     similar_opcode,
     skip,
     try_set,
@@ -193,43 +191,3 @@ def test_code_cmp() -> None:
     assert code_cmp(test("lambda: j"), test_case())
     ## different code objects ##
     assert code_cmp(test("lambda x: x"), test("lambda x: x + 1")) == False
-
-
-def test_is_running() -> None:
-    ## without tracking ##
-    def test_case():
-        yield 1
-
-    try:
-        is_running(test_case())
-        assert False
-    except TypeError:
-        pass
-    ## with tracking ##
-    from gcopy.track import track
-
-    iterator = track(test_case())
-    assert is_running(iterator) == False
-    next(iterator)
-    assert is_running(iterator)
-
-    ## iterator with end index ##
-    def test(iterator: Iterator) -> None:
-        iterator = iter(iterator)
-        assert is_running(iterator) == False
-        next(iterator)
-        assert is_running(iterator)
-
-    test(range(3))
-    ## requiring c level memory access ##
-    test(memoryview(bytearray([1, 2, 3])))
-    test({1, 2, 3})
-    test(frozenset({1, 2, 3}))
-    test({"a": 1, "b": 2, "c": 3})
-    ## zip ##
-    test(zip([1, 2, 3], [1, 2, 3]))
-    ## enumerate ##
-    test(enumerate([1, 2, 3]))
-    ## map + filter ##
-    test(map(lambda x: x, [1, 2, 3]))
-    test(filter(lambda x: x, [1, 2, 3]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+## getcode, getframe raises a runtime warning because we didn't use the coroutine i.e. in an event loop ##
+## is_cli is tested in test_cli_findsource ##
+
 import warnings
 from sys import version_info
 from types import CodeType, FrameType
@@ -5,7 +8,6 @@ from typing import Iterator
 
 from gcopy.utils import (
     attr_cmp,
-    chain,
     cli_findsource,
     code_attrs,
     code_cmp,
@@ -72,44 +74,46 @@ def test_getcode() -> None:
     ## generator ##
     assert type(getcode((i for i in (None,)))) == CodeType
 
-    ## coroutine ##
-    async def t():
-        pass
+    with warnings.catch_warnings():
+        ## raises a runtime warning because we didn't use the coroutine i.e. in an event loop ##
+        warnings.simplefilter("ignore")
 
-    assert type(getcode(t())) == CodeType
+        ## coroutine ##
+        async def t():
+            pass
 
-    ## async generator ##
-    async def t():
-        yield 1
+        assert type(getcode(t())) == CodeType
 
-    assert type(getcode(t())) == CodeType
+        ## async generator ##
+        async def t():
+            yield 1
+
+        assert type(getcode(t())) == CodeType
 
 
 def test_getframe() -> None:
     ## generator ##
     assert type(getframe((i for i in (None,)))) == FrameType
 
-    ## coroutine ##
-    async def t():
-        pass
+    with warnings.catch_warnings():
+        ## raises a runtime warning because we didn't use the coroutine i.e. in an event loop ##
+        warnings.simplefilter("ignore")
 
-    assert type(getframe(t())) == FrameType
+        ## coroutine ##
+        async def t():
+            pass
 
-    ## async generator ##
-    async def t():
-        yield 1
+        assert type(getframe(t())) == FrameType
 
-    assert type(getframe(t())) == FrameType
+        ## async generator ##
+        async def t():
+            yield 1
+
+        assert type(getframe(t())) == FrameType
 
 
 def test_hasattrs() -> None:
     assert hasattrs(compile("1+1", "", "eval"), code_attrs())
-
-
-def test_chain() -> None:
-    ls = list(range(1, 5))
-    for i in chain([1, 2], [3, 4]):
-        assert i == ls.pop(0)
 
 
 def test_get_nonlocals() -> None:
@@ -229,26 +233,3 @@ def test_is_running() -> None:
     ## map + filter ##
     test(map(lambda x: x, [1, 2, 3]))
     test(filter(lambda x: x, [1, 2, 3]))
-
-
-if __name__ == "__main__":
-    # TODO can remove, simply run pytest .
-    ## is_cli is tested in test_cli_findsource ##
-    test_cli_findsource()
-    test_skip()
-    test_empty_generator()
-    test_code_attrs()
-    test_attr_cmp()
-    with warnings.catch_warnings():
-        ## raises a runtime warning because we didn't use the coroutine i.e. in an event loop ##
-        warnings.simplefilter("ignore")
-        test_getcode()
-        test_getframe()
-    test_hasattrs()
-    test_chain()
-    test_get_nonlocals()
-    test_try_set()
-    test_get_globals()
-    test_similar_opcode()
-    test_code_cmp()
-    test_is_running()


### PR DESCRIPTION
 - Fixed slicing
 - Removed unnecessary imports and code
 - Added the patch_iterators initialization to custom_generator.py
 - Fixed scope error in sign function in source_processing.py 
 - Fixed uninitialized iteration behaviour

All tests still work without pytest it's just that pytest adds stuff to the ```globals()``` that messes with tests that are reliant on ```globals()``` i.e. some tests are failing from ```globals()``` or ```inspect.currentframe()``` most likely.

With pytest running I get:

![image](https://github.com/user-attachments/assets/43d007ea-820f-48b8-8600-0435908bd299)


I'm thinking about how to scope the patches to avoid assigning them into globals but the problem you encounter if you do so is that we're essentially wanting unbound locals to be dynamically defined which I don't think python lets us do because it will compile any unbound locals that are not assigned as being globals/builtins/ or nonlocals/closures if these are defined.

I.e.:
```python
import ctypes
from inspect import currentframe
from gcopy.track import patch_iterators

def test():
    range = 3  # we don't want this line here but it's needed at compile time (I think) to indicate its scoping
    local_frame = currentframe()
    patch_iterators(local_frame.f_locals)
    # only needed in python versions before PEP 667 implementation (I think)
    # e.g. when locals was only a static view rather than the live view
    ctypes.pythonapi.PyFrame_LocalsToFast(ctypes.py_object(local_frame), ctypes.c_int(0))
    for i in range(3):
        print(locals()[".internals"][".4"])
test()
```